### PR TITLE
moved autocast to compute_loss and enabled unet_hpu

### DIFF
--- a/examples/trl/ddpo.py
+++ b/examples/trl/ddpo.py
@@ -242,8 +242,7 @@ if __name__ == "__main__":
         use_hpu_graphs=args.use_hpu_graphs,
     )
 
-    with torch.autocast(device_type="hpu", dtype=torch.bfloat16):
-        trainer.train()
+    trainer.train()
 
     if args.push_to_hub:
         trainer.push_to_hub(args.hf_hub_model_id, token=args.hf_user_access_token)

--- a/optimum/habana/trl/models/modeling_sd_base.py
+++ b/optimum/habana/trl/models/modeling_sd_base.py
@@ -499,7 +499,8 @@ class GaudiDefaultDDPOStableDiffusionPipeline(DefaultDDPOStableDiffusionPipeline
         self.sd_pipeline.unet.requires_grad_(not self.use_lora)
 
     def __call__(self, *args, **kwargs) -> DDPOPipelineOutput:
-        return pipeline_step(self.sd_pipeline, *args, **kwargs)
+        with torch.autocast(device_type="hpu", dtype=torch.bfloat16, enabled=self.gaudi_config.use_torch_autocast):
+            return pipeline_step(self.sd_pipeline, *args, **kwargs)
 
     def scheduler_step(self, *args, **kwargs) -> DDPOSchedulerOutput:
         return scheduler_step(self.sd_pipeline.scheduler, *args, **kwargs)
@@ -507,6 +508,10 @@ class GaudiDefaultDDPOStableDiffusionPipeline(DefaultDDPOStableDiffusionPipeline
     @property
     def unet(self):
         return self.sd_pipeline.unet
+    
+    @property
+    def unet_hpu(self):
+        return self.sd_pipeline.unet_hpu
 
     @property
     def vae(self):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Autocast moved from ddpo.py to ddpo_trainer.py calculate_loss()

calculate_loss() now calls unet_hpu() to manage enable --use_hpu_graphs True


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
